### PR TITLE
Add Ansible Playbook for remote java development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "java",
-            "name": "Debug (Attach to z/OS)",
-            "request": "attach",
-            "hostName": "10.244.64.16", // replace with your z/OS system's IP
-            "port": 8000
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Debug (Attach to z/OS)",
+      "request": "attach",
+      "hostName": "example.com", // replace with your z/OS system's IP
+      "port": 8000
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic",
-    "editor.formatOnSave": true,
-    "java.dependency.packagePresentation": "hierarchical"
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "editor.formatOnSave": true,
+  "java.dependency.packagePresentation": "hierarchical",
+  "ansible.python.interpreterPath": "/usr/local/bin/python3"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,42 +7,54 @@
  * Contract with IBM Corp.
  *******************************************************************************/
 {
-	"version": "2.0.0",
-	"inputs": [
-		{
-			"type": "command",
-			"id": "targetFile",
-			"command": "extension.commandvariable.file.pickFile",
-			"args": {
-				"description": "Select a jar file to run",
-				"include": "target/*.jar",
-				"transform": {
-					"text": "${file}",
-					"find": "\\\\",
-					"replace": "/",
-					"flags": "g"
-				}
-			}
-		},
-		{
-			"type": "promptString",
-			"id": "programInput",
-			"description": "Program input",
-			"default": "\"//SAMPLE.COBOL\""
-		}
-	],
-	"tasks": [
-		{
-			"label": "Run Java program on z/OS",
-			"type": "shell",
-			"command": "scripts/run-zos.sh \"${input:targetFile}\" ${input:programInput}",
-			"problemMatcher": []
-		},
-		{
-			"label": "Debug Java program on z/OS",
-			"type": "shell",
-			"command": "scripts/run-zos.sh \"${input:targetFile}\" ${input:programInput} debug=true",
-			"problemMatcher": []
-		}
-	]
+  "version": "2.0.0",
+  "inputs": [
+    {
+      "type": "command",
+      "id": "targetFile",
+      "command": "extension.commandvariable.file.pickFile",
+      "args": {
+        "description": "Select a jar file to run",
+        "include": "target/*.jar",
+        "transform": {
+          "text": "${file}",
+          "find": "\\\\",
+          "replace": "/",
+          "flags": "g"
+        }
+      }
+    },
+    {
+      "type": "promptString",
+      "id": "programInput",
+      "description": "Program input",
+      "default": "\"//SAMPLE.COBOL\""
+    }
+  ],
+  "tasks": [
+    {
+      "label": "Run Java program on z/OS (Zowe)",
+      "type": "shell",
+      "command": "scripts/run-zos.sh \"${input:targetFile}\" ${input:programInput}",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Java program on z/OS (Ansible)",
+      "type": "shell",
+      "command": "ansible-playbook -i scripts/ansible/inventory/inventory.yml scripts/ansible/run-zos.yml --extra-vars \"target_file='${input:targetFile}' program_input='${input:programInput}' debug=false\"",
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug Java program on z/OS",
+      "type": "shell",
+      "command": "scripts/run-zos.sh \"${input:targetFile}\" ${input:programInput} debug=true",
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug Java program on z/OS (Ansible)",
+      "type": "shell",
+      "command": "ansible-playbook -i scripts/ansible/inventory/inventory.yml scripts/ansible/run-zos.yml --extra-vars \"target_file='${input:targetFile}' program_input='${input:programInput}' debug=true\"",
+      "problemMatcher": []
+    }
+  ]
 }

--- a/scripts/ansible/ansible.cfg
+++ b/scripts/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+deprecation_warnings=False

--- a/scripts/ansible/inventory/host_vars/server.yml
+++ b/scripts/ansible/inventory/host_vars/server.yml
@@ -1,0 +1,14 @@
+###############################################################################
+# Licensed Materials - Property of IBM
+# (c) Copyright IBM Corporation 2024. All Rights Reserved.
+#
+# Note to U.S. Government Users Restricted Rights:
+# Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+###############################################################################
+
+---
+ssh_port: 22
+pyz: "/usr/lpp/IBM/cyp/v3r8/pyz"
+java_home: "/usr/lpp/java/J8.0_64"
+ansible_python_interpreter: "{{ pyz }}/bin/python3.8"

--- a/scripts/ansible/inventory/inventory.yml
+++ b/scripts/ansible/inventory/inventory.yml
@@ -1,0 +1,23 @@
+###############################################################################
+# Licensed Materials - Property of IBM
+# (c) Copyright IBM Corporation 2024. All Rights Reserved.
+#
+# Note to U.S. Government Users Restricted Rights:
+# Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+###############################################################################
+
+################################################################################
+# Description of the properties used in this configuration:
+# - Property `ansible_host` is the z/OS managed node (target),
+#    e.g, ansible_host: "example.com"
+# - Property `ansible_user` is the z/OS managed user to connect and run as over SSH,
+#    e.g, ansible_user: "user"
+################################################################################
+
+source_system:
+  hosts:
+    server:
+      ansible_user: user
+      ansible_host: example.com
+      ansible_port: 22

--- a/scripts/ansible/run-zos.yml
+++ b/scripts/ansible/run-zos.yml
@@ -1,0 +1,44 @@
+################################################################
+# LICENSED MATERIALS - PROPERTY OF IBM
+# "RESTRICTED MATERIALS OF IBM"
+# (C) COPYRIGHT IBM CORPORATION 2024. ALL RIGHTS RESERVED
+# US GOVERNMENT USERS RESTRICTED RIGHTS - USE, DUPLICATION,
+# OR DISCLOSURE RESTRICTED BY GSA ADP SCHEDULE
+# CONTRACT WITH IBM CORPORATION
+################################################################
+
+---
+- name: Run java sample
+  hosts: "{{ host | default('server') }}"
+  vars:
+    debug_option: "{{ '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000' if debug | bool else None }}"
+    remote_program: "/u/{{ ansible_user }}/projects/java/{{ target_file | basename }}"
+  gather_facts: false
+  tasks:
+    # Upload of jar file to z/OS using Zowe CLI
+    - name: Upload Jar File to z/OS
+      ibm.ibm_zos_core.zos_copy:
+        src: "{{ playbook_dir }}../../../target/jzos-samples-1.0-SNAPSHOT.jar"
+        dest: "/u/{{ ansible_user }}/projects/java"
+        is_binary: true
+        mode: u+rwx
+
+    # Show which port the server is running on
+    - name: Show Port Server Is Running On
+      ansible.builtin.debug:
+        msg: "Listening for transport dt_socket at address: 8000"
+      when: debug | bool
+
+    # Start Java application in z/OS
+    - name: Start Java Application
+      ansible.builtin.shell:
+        cmd: '. /u/{{ ansible_user | quote }}/.profile && java {{ debug_option }} -jar "{{ remote_program | quote }}" "{{ program_input | quote }}"'
+        chdir: "/u/{{ ansible_user | quote }}"
+        executable: /bin/bash
+      register: report
+      changed_when: report.rc == 0
+
+    # Show output of Java
+    - name: Show output
+      ansible.builtin.debug:
+        var: report.stdout_lines


### PR DESCRIPTION
# Run & Debug remote Java on z/OS with Ansible Playbook

This PR adds a new Ansible Playbook for running and debugging remote java, this can all be done through a VS Code task that has been created in the project. The Ansible Playbook will do the following when running/debugging java:

- Upload to z/OS the compiled `.jar` file
- Start the debug server that can later be attached to from VS Code locally once started
- Return the output of the Java program